### PR TITLE
added check to harbor's /api/version endpoint before rewriting the image

### DIFF
--- a/docs/example-config/static.yaml
+++ b/docs/example-config/static.yaml
@@ -6,3 +6,4 @@ verbose: false
 static:
   registry_caches:
     docker.io: "harbor.example.com/dockerhub-proxy"
+  harbor_endpoint: https://harbor.example.com

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -60,4 +60,6 @@ type DynamicProxy struct {
 type StaticProxy struct {
 	// RegistryCaches is an map of registries to harbor projects
 	RegistryCaches map[string]string `yaml:"registry_caches"`
+	// HarborEndpoint is the address to query for harbor projects and discover proxy cache configuration.
+	HarborEndpoint string `yaml:"harbor_endpoint"`
 }


### PR DESCRIPTION
Suggestion of implementation for issue https://github.com/indeedeng-alpha/harbor-container-webhook/issues/7. Simply checking for 200 status in <HABOR_URL>/api/version before rewriting.

I have not run go test.