### PR TITLE
add bypass_image_list to static conf

### DIFF
--- a/deploy/charts/harbor-container-webhook/values.yaml
+++ b/deploy/charts/harbor-container-webhook/values.yaml
@@ -99,3 +99,5 @@ static:
   skip_tls_verify: false
   harbor_endpoint: https://harbor.example.com
   verify_harbor_api: true
+  bypass_image_list:
+  - "^goharbor/.*"

--- a/hack/hack-static.yaml
+++ b/hack/hack-static.yaml
@@ -9,3 +9,5 @@ static:
   skip_tls_verify: false
   harbor_endpoint: https://harbor.example.com
   verify_harbor_api: true
+  bypass_image_list:
+  - "^goharbor/.*"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -68,4 +68,6 @@ type StaticProxy struct {
 	HarborEndpoint string `yaml:"harbor_endpoint"`
 	// Verify the harbor API is responding to the harbor_endpoint before transforming container images.
 	VerifyHarborAPI bool `yaml:"verify_harbor_api"`
+	// Array of regexes of images to bypass
+	BypassImageList []string `yaml:"bypass_image_list",flow`
 }


### PR DESCRIPTION
When the kubernetes cluster starts or when a node is drained, despite the API check there can be a case when Harbor images are rewritten by the webhook but, in a few seconds, Harbor core or database is down and the images cannot be pulled. So we have to manually redeploy the containers.

To fix this we could have a option that have a list of regexes of images that the webhook should bypass. This PR contains the proposed fix. It is implemented only in the static mode. And the tests were not validated.