### PR TITLE
feat(helm): add initContainers

### DIFF
--- a/deploy/charts/harbor-container-webhook/templates/deployment.yaml
+++ b/deploy/charts/harbor-container-webhook/templates/deployment.yaml
@@ -29,6 +29,10 @@ spec:
       priorityClassName: {{ .Values.priorityClassName }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if .Values.initContainers }}
+      initContainers:
+        {{- toYaml .Values.initContainers | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           args:

--- a/deploy/charts/harbor-container-webhook/values.yaml
+++ b/deploy/charts/harbor-container-webhook/values.yaml
@@ -39,6 +39,8 @@ service:
   type: ClusterIP
   port: 9443
 
+initContainers: []
+
 resources: {}
 
 nodeSelector: {}


### PR DESCRIPTION
Hi,

your approach with this repo is a really good one and I want to use it by myself - so thank you for sharing it!

Because I want to make small changes how the certificates are treated I would need to add a [initContainer](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/).
Because of that it would be great to extend your Helm chart.

I also require a volume (separate PR #19).