### PR TITLE
feat(helm): added certManager duration and renewBefore configurations to values.yaml

### DIFF
--- a/deploy/charts/harbor-container-webhook/templates/certificate.yaml
+++ b/deploy/charts/harbor-container-webhook/templates/certificate.yaml
@@ -8,8 +8,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   secretName: {{ include "harbor-container-webhook.fullname" . }}-certs
-  duration: 2160h0m0s
-  renewBefore: 360h0m0s
+  duration: {{ .Values.certManager.duration }}
+  renewBefore: {{ .Values.certManager.renewBefore }}
   commonName: {{ include "harbor-container-webhook.fullname" . }}.{{ .Release.Namespace }}.svc
   dnsNames:
     - {{ include "harbor-container-webhook.fullname" . }}

--- a/deploy/charts/harbor-container-webhook/values.yaml
+++ b/deploy/charts/harbor-container-webhook/values.yaml
@@ -61,6 +61,8 @@ priorityClassName: ""
 certManager:
   enabled: true
   apiVersion: "cert-manager.io/v1"
+  duration: 2160h0m0s
+  renewBefore: 360h0m0s
 
 webhook:
   namespaceSelector:


### PR DESCRIPTION
We have alerts that trigger when certificates are about to expire in less than 30 days. This change would allow us to set a longer duration and avoid triggering the alerts.